### PR TITLE
Fix unnecessarily expensive PresentationOffset().

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -9,7 +9,6 @@ package reisen
 // #include <inttypes.h>
 import "C"
 import (
-	"fmt"
 	"time"
 )
 
@@ -33,10 +32,7 @@ type baseFrame struct {
 // should be played.
 func (frame *baseFrame) PresentationOffset() (time.Duration, error) {
 	tbNum, tbDen := frame.stream.TimeBase()
-	tb := float64(tbNum) / float64(tbDen)
-	tm := float64(frame.pts) * tb
-
-	return time.ParseDuration(fmt.Sprintf("%fs", tm))
+	return time.Second * time.Duration(tbNum) * time.Duration(frame.pts) / time.Duration(tbDen), nil
 }
 
 // IndexCoded returns the index of


### PR DESCRIPTION
This code isn't being used at the moment, but it's an obstacle if we try to get video and audio in sync using `PresentationOffset()`.

Before:
![before](https://github.com/user-attachments/assets/bc8602b5-6319-415e-88c9-46f4c1e036c8)

After:
![after](https://github.com/user-attachments/assets/a690d9a8-5a71-4a6c-b10e-6dedaea70887)
